### PR TITLE
Include "libs_src" in "source-path".

### DIFF
--- a/vscode-extension/src/main/ts/commands/createNewProject.ts
+++ b/vscode-extension/src/main/ts/commands/createNewProject.ts
@@ -391,7 +391,7 @@ function createAsconfigJson(
 	"compilerOptions": {
 		"source-path": [
 			"src",
-			"libs-src"
+			"libs_src"
 		],
 		"library-path": [
 			"libs"
@@ -412,7 +412,7 @@ function createAsconfigJsonRoyale(mainClassName: string): string {
 		],
 		"source-path": [
 			"src",
-			"libs-src"
+			"libs_src"
 		],
 		"library-path": [
 			"libs"

--- a/vscode-extension/src/main/ts/commands/createNewProject.ts
+++ b/vscode-extension/src/main/ts/commands/createNewProject.ts
@@ -390,7 +390,8 @@ function createAsconfigJson(
 	"config": ${mobile ? `"airmobile"` : `"air"`},
 	"compilerOptions": {
 		"source-path": [
-			"src"
+			"src",
+			"libs-src"
 		],
 		"library-path": [
 			"libs"
@@ -410,7 +411,8 @@ function createAsconfigJsonRoyale(mainClassName: string): string {
 			"JSRoyale"
 		],
 		"source-path": [
-			"src"
+			"src",
+			"libs-src"
 		],
 		"library-path": [
 			"libs"


### PR DESCRIPTION
Source based APM packages such as `starling-source`  (for example), install into `libs_src`, but this is currently not defined in the stock `asconfig.json` provided by the extension.

This pull request includes `"libs_src"` in the `asconfig.json` template, so no user intervention is needed to include the `libs_src` folder in `asconfig.json`.